### PR TITLE
Fixed StringToSign calculation error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -103,7 +103,7 @@ class Client extends Base {
       var list = new Array(keys.length);
       for (var i = 0; i < keys.length; i++) {
         var key = keys[i];
-        if (toStringify[key] && ('' + toStringify[key])) {
+        if (toStringify[key]!==undefined && toStringify[key]!==null && ('' + toStringify[key])) {
           list[i] = `${key}=${toStringify[key]}`;
         } else {
           list[i] = `${key}`;


### PR DESCRIPTION
There is a bug.Client StringToSign and Server StringToSign are different when the value in request query params or data is "false" or 0.It causes Invalid Signature error.I fixed it.